### PR TITLE
Stack Trace

### DIFF
--- a/app/lib/err_handler.js
+++ b/app/lib/err_handler.js
@@ -20,13 +20,15 @@ const api_errcode = {
 
 // code : 0 -> Built-in error, 1 -> App-sequence error, other -> API error
 class AppError extends Error {
-    constructor(sustainable, code, ...params) {
-        // Pass remaining arguments (including vendor specific ones) to parent constructor
-        super(...params);
+    constructor(sustainable, code, err) {
+        super(err);
 
         // Maintains proper stack trace for where our error was thrown (only available on V8)
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, AppError);
+        }
+        if(err instanceof Error){
+            this.stack = err.stack;
         }
 
         this.sustainable = sustainable;

--- a/app/lib/setting_operator.js
+++ b/app/lib/setting_operator.js
@@ -39,7 +39,7 @@ class AppSetting{
                            "token": this.ac.token};
         fs.writeFile(path, JSON.stringify(export_json, null, 1), (err) => {
             if(err){
-                throw new AppError(true, 0, err.message);
+                throw new AppError(true, 0, err);
             }
         });
     }

--- a/app/lib/tag_analyzer.js
+++ b/app/lib/tag_analyzer.js
@@ -87,7 +87,7 @@ class TagAnalyzer {
             if(err instanceof AppError){
                 throw err;
             } else {
-                throw new AppError(false, 0, err.message); // treat Built-in Error as a critical error
+                throw new AppError(false, 0, err); // treat Built-in Error as a critical error
             }
         }
     }
@@ -112,7 +112,7 @@ class TagAnalyzer {
             if(err instanceof AppError){
                 throw err;
             } else {
-                throw new AppError(false, 0, err.message); // treat Built-in Error as a critical error
+                throw new AppError(false, 0, err); // treat Built-in Error as a critical error
             }
         }
     }

--- a/app/lib/token_operator.js
+++ b/app/lib/token_operator.js
@@ -80,7 +80,7 @@ async function validateAccessInfo(ac, log){
         if(err instanceof AppError){
             throw err;
         } else {
-            throw new AppError(false, 0, err.message); // treat Built-in Error as a critical error
+            throw new AppError(false, 0, err); // treat Built-in Error as a critical error
         }
     }
 }
@@ -154,7 +154,7 @@ async function generatePermanentToken(first_token, app_id, app_secret, pagename,
         if(err instanceof AppError){
             throw err;
         } else {
-            throw new AppError(false, 0, err.message); // treat Built-in Error as a critical error
+            throw new AppError(false, 0, err); // treat Built-in Error as a critical error
         }
     }
 }


### PR DESCRIPTION
Built-in ErrorからAppErrorを生成した際い、元々のスタックトレースをコピーするようにした。
Built-in Errorをcatchしてthrow new AppErrorした行より深いトレースが消失していた問題 #26 を解消した。